### PR TITLE
Fix typo in Section 2.3: Generalized induction and recursion

### DIFF
--- a/_sources/mathematical_background.rst.txt
+++ b/_sources/mathematical_background.rst.txt
@@ -280,7 +280,7 @@ More generally, we can take :math:`[a, b, c, \ldots]` to be an abbreviation for
 :math:`a \mathbin{::} (b \mathbin{::} (c \mathbin{::} \ldots []))`.
 
 Saying that :math:`\fn{List}(\alpha)` is inductively defined means
-that we principles of recursion and induction on it. For example, the following
+that we can use principles of recursion and induction on it. For example, the following
 concatenates two lists:
 
 .. math::


### PR DESCRIPTION
Minor typo correction, change as follows:

Replace:
`...means that we principles of recursion and induction...` 

With:
`...means that we *can use* principles of recursion and induction...`

It looks like the real backing source repository for the `lamr` textbook isn't publicly available, so this change is made against the Sphinx-generated content on the GitHub Pages branch.  Hopefully a concrete pull request will be easier to use in fixing the upstream text than a textual description of the change via GitHub issue.  